### PR TITLE
added integration_id, iframe_id and hmac_secret to paymob config file

### DIFF
--- a/src/Paymob.php
+++ b/src/Paymob.php
@@ -65,11 +65,12 @@ class Paymob
      * @param int $orderId
      * @param array $billingData
      * @param string $currency
-     * @param int $integrationId
      * @return array
      */
-    public function getPaymentKey(string $token, int $amountCents, int $expiration, int $orderId, array $billingData, string $currency, int $integrationId): array
+    public function getPaymentKey(string $token, int $amountCents, int $expiration, int $orderId, array $billingData, string $currency): array
     {
+        $integrationId = config('paymob.auth.integration_id');
+        
         $json = [
             'auth_token' => $token,
             'amount_cents' => $amountCents,
@@ -96,8 +97,9 @@ class Paymob
      */
     public function makePayment(string $paymentToken): string
     {
+        $iframeId = config('paymob.auth.iframe_id');
         $response = Http::get(
-            'https://accept.paymobsolutions.com/api/acceptance/iframes/455520?payment_token='.$paymentToken,
+            'https://accept.paymobsolutions.com/api/acceptance/iframes/'. $iframeId .'?payment_token='.$paymentToken,
         );
 
         return $response->body();

--- a/src/config/paymob.php
+++ b/src/config/paymob.php
@@ -27,5 +27,8 @@ return [
     */
     'auth' => [
         'api_key'    => env('PAYMOB_API_KEY'),
+        'integration_id' => env('PAYMOB_INTEGRATION_ID'),
+        'iframe_id' => env('PAYMOB_IFRAME_ID'),
+        'hmac_secret' => env('PAYMOB_HMAC_SECRET')
     ],
 ];


### PR DESCRIPTION
1- Added integartion_id, iframe_id and hmac_secret to paymob.php config file to make it more dynamic.

2- Used integration_id and iframe_id from config file in Paymob class.

```
    'auth' => [
        ...
        'integration_id' => env('PAYMOB_INTEGRATION_ID'),
        'iframe_id' => env('PAYMOB_IFRAME_ID'),
        'hmac_secret' => env('PAYMOB_HMAC_SECRET')
    ],
```